### PR TITLE
Fixed typo in popup and added saved itinerary when a new one is added.

### DIFF
--- a/scripts/savedItinerary/saveItinerary.js
+++ b/scripts/savedItinerary/saveItinerary.js
@@ -30,9 +30,10 @@ export const  saveItin = (itineraryObj) =>{
             .then(data => {
               alert(`The itinerary : ${data.itineraryName} was saved`)
               modal.style.display = "none"
+              getSavedItinerary()
           })
         }else {
-            alert("enter am Itinerary Name");
+            alert("enter an Itinerary Name");
             input.focus();
         };
         


### PR DESCRIPTION
# Description

Fixed a typo in popup and recreated the saved itinerary list when a new itinerary is saved.


## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)


# Testing Instructions

User should load site and click to create a itinerary. They should then click save and attempt to save without an itinerary name. They should receive a popup with the correct verbiage "an itinerary" instead of "am itinerary".
The user should also create an itinerary and save it. The saved itinerary list should populate with the latest one.

# Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings or errors
- [ x] I have added test instructions that prove my fix is effective or that my feature works
